### PR TITLE
CRUD/operador

### DIFF
--- a/everywhere-backend/src/main/java/com/everywhere/backend/api/OperadorController.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/api/OperadorController.java
@@ -1,0 +1,75 @@
+package com.everywhere.backend.api;
+
+import com.everywhere.backend.mapper.OperadorMapper;
+import com.everywhere.backend.model.dto.OperadorRequestDto;
+import com.everywhere.backend.model.dto.OperadorResponseDto;
+import com.everywhere.backend.model.entity.Operador;
+import com.everywhere.backend.repository.OperadorRepository;
+import com.everywhere.backend.service.OperadorService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/operadores")
+public class OperadorController {
+
+    private OperadorService operadorService;
+
+    public OperadorController(OperadorService operadorService) {
+        this.operadorService = operadorService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<OperadorResponseDto>> findAll() {
+        List<OperadorResponseDto> response = operadorService.findAll()
+                .stream()
+                .map(OperadorMapper::toResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<OperadorResponseDto> getById(@PathVariable Integer id) {
+        return operadorService.findById(id)
+                .map(OperadorMapper::toResponse)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<OperadorResponseDto> create(@RequestBody OperadorRequestDto dto) {
+        Operador operador = OperadorMapper.toEntity(dto);
+        Operador nuevoOperador = operadorService.save(operador);
+        return new ResponseEntity<>(OperadorMapper.toResponse(nuevoOperador), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<OperadorResponseDto> update(
+            @PathVariable Integer id,
+            @RequestBody OperadorRequestDto dto) {
+
+        return operadorService.findById(id)
+                .map(existing -> {
+                    existing.setNombre(dto.getNombre());
+
+                    Operador updated = operadorService.update(existing);
+
+                    return ResponseEntity.ok(OperadorMapper.toResponse(updated));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+        if (operadorService.findById(id).isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        operadorService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/mapper/OperadorMapper.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/mapper/OperadorMapper.java
@@ -1,0 +1,31 @@
+package com.everywhere.backend.mapper;
+
+import com.everywhere.backend.model.dto.OperadorRequestDto;
+import com.everywhere.backend.model.dto.OperadorResponseDto;
+import com.everywhere.backend.model.entity.Operador;
+
+public class OperadorMapper {
+
+    public static Operador toEntity(OperadorRequestDto dto) {
+        if (dto == null) {
+            return null;
+        }
+
+        Operador operador = new Operador();
+        operador.setNombre(dto.getNombre());
+        return operador;
+    }
+
+    public static OperadorResponseDto toResponse(Operador operador) {
+        if (operador == null) {
+            return null;
+        }
+        OperadorResponseDto dto = new OperadorResponseDto();
+        dto.setId(operador.getId());
+        dto.setNombre(operador.getNombre());
+        dto.setCreado(operador.getCreado());
+        dto.setActualizado(operador.getActualizado());
+        return dto;
+    }
+
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/OperadorRequestDto.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/OperadorRequestDto.java
@@ -1,0 +1,12 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OperadorRequestDto {
+    String nombre;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/OperadorResponseDto.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/OperadorResponseDto.java
@@ -1,0 +1,22 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * DTO for {@link com.everywhere.backend.model.entity.Operador}
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OperadorResponseDto implements Serializable {
+    int id;
+    String nombre;
+    LocalDateTime creado;
+    LocalDateTime actualizado;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/Operador.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/Operador.java
@@ -14,7 +14,7 @@ public class Operador {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "opr_id_int")
-    private Long id;
+    private int id;
 
     @Column(name = "opr_nomb_int", length = 150)
     private String nombre;

--- a/everywhere-backend/src/main/java/com/everywhere/backend/repository/OperadorRepository.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/repository/OperadorRepository.java
@@ -1,0 +1,16 @@
+package com.everywhere.backend.repository;
+
+import com.everywhere.backend.model.entity.Operador;
+import jdk.jfr.Registered;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OperadorRepository extends JpaRepository<Operador, Integer> {
+
+    Optional<Operador> findByNombre(String nombre);
+
+    List<Operador> nombre(String nombre);
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/OperadorService.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/OperadorService.java
@@ -1,0 +1,21 @@
+package com.everywhere.backend.service;
+
+import com.everywhere.backend.model.entity.Operador;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OperadorService {
+
+    List<Operador> findAll();
+
+    Optional<Operador> findByNombre(String nombre);
+
+    Optional<Operador> findById(int id);
+
+    Operador save(Operador operador);
+
+    Operador update(Operador operador);
+
+    void deleteById(int id);
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/OperadorServiceImpl.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/OperadorServiceImpl.java
@@ -1,0 +1,54 @@
+package com.everywhere.backend.service.impl;
+
+import com.everywhere.backend.model.entity.Operador;
+import com.everywhere.backend.repository.OperadorRepository;
+import com.everywhere.backend.service.OperadorService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class OperadorServiceImpl implements OperadorService {
+
+    private final OperadorRepository operadorRepository;
+
+    public OperadorServiceImpl(OperadorRepository operadorRepository) {
+        this.operadorRepository = operadorRepository;
+    }
+
+    @Override
+    public List<Operador> findAll() {
+        return operadorRepository.findAll();
+    }
+
+    @Override
+    public Optional<Operador> findByNombre(String nombre) {
+        return operadorRepository.findByNombre(nombre);
+    }
+
+    @Override
+    public Optional<Operador> findById(int id) {
+        return operadorRepository.findById(id);
+    }
+
+    @Override
+    public Operador save(Operador operador) {
+        return operadorRepository.save(operador);
+    }
+
+    @Override
+    public Operador update(Operador operador) {
+        Optional<Operador> optional = operadorRepository.findById(operador.getId());
+        if (optional.isEmpty()) {
+            throw new RuntimeException("Operador con id " + operador.getId() + " no encontrado");
+        }
+        return operadorRepository.save(operador);
+    }
+
+    @Override
+    public void deleteById(int id) {
+        operadorRepository.deleteById(id);
+    }
+}
+


### PR DESCRIPTION
Se implementó un sistema CRUD completo para la entidad Operador, siguiendo las buenas prácticas aplicadas previamente en el módulo de Proveedor y Sucursal.
Incluye el uso de DTOs, Mapper, Service, Repository y Controller, asegurando una correcta separación de responsabilidades.

Arquitectura mejorada

- DTOs separados: OperadorRequestDto y OperadorResponseDto para separar datos de entrada y salida.

- Constructor injection: Uso de inyección por constructor en lugar de @Autowired.

- Mapper: Implementación de OperadorMapper para conversión entre entidad y DTOs.

- Validaciones: Preparado para integrar validaciones con Jakarta Validation.

Endpoints

GET /api/v1/operadores → Listar todos los operadores.
GET /api/v1/operadores/{id} → Obtener un operador por su ID.
POST /api/v1/operadores → Crear un nuevo operador.
PUT /api/v1/operadores/{id} → Actualizar un operador existente (ejemplo: nombre).
DELETE /api/v1/operadores/{id} → Eliminar un operador por su ID.
