### PR TITLE
CRUD/counter

### DIFF
--- a/everywhere-backend/src/main/java/com/everywhere/backend/api/CounterController.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/api/CounterController.java
@@ -1,5 +1,69 @@
 package com.everywhere.backend.api;
 
+
+import com.everywhere.backend.model.dto.CounterRequestDto;
+import com.everywhere.backend.model.dto.CounterResponseDto;
+import com.everywhere.backend.service.CounterService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/counters")
+@RequiredArgsConstructor
 public class CounterController {
-    
+
+    private final CounterService counterService;
+
+    @PostMapping
+    public ResponseEntity<CounterResponseDto> create(@RequestBody CounterRequestDto request) {
+        return ResponseEntity.ok(counterService.create(request));
+    }
+
+
+    @PutMapping
+    public ResponseEntity<CounterResponseDto> update(@RequestBody CounterRequestDto request) {
+        return ResponseEntity.ok(counterService.update(request));
+    }
+
+    @PatchMapping("/activate")
+    public ResponseEntity<CounterResponseDto> activate(@RequestBody CounterRequestDto request) {
+        return ResponseEntity.ok(counterService.activate(
+                request.getCodigo() != null ? request.getCodigo() : request.getNombre()
+        ));
+    }
+
+    @PatchMapping("/desactivate")
+    public ResponseEntity<CounterResponseDto> deactivate(@RequestBody CounterRequestDto request) {
+        return ResponseEntity.ok(counterService.deactivate(
+                request.getCodigo() != null ? request.getCodigo() : request.getNombre()
+        ));
+    }
+
+    //Get counter by code
+    @GetMapping("/search")
+    public ResponseEntity<CounterResponseDto> get(@RequestBody CounterRequestDto request) {
+        return counterService.get(
+                        request.getCodigo() != null ? request.getCodigo() : request.getNombre()
+                ).map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    //Get all counters
+    @GetMapping
+    public ResponseEntity<List<CounterResponseDto>> getAll() {
+        return ResponseEntity.ok(counterService.getAll());
+    }
+
+    @GetMapping("/activos")
+    public ResponseEntity<List<CounterResponseDto>> getActivos() {
+        return ResponseEntity.ok(counterService.listActive());
+    }
+
+    @GetMapping("/inactivos")
+    public ResponseEntity<List<CounterResponseDto>> getInactivos() {
+        return ResponseEntity.ok(counterService.listInactive());
+    }
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/mapper/CounterMapper.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/mapper/CounterMapper.java
@@ -1,0 +1,24 @@
+package com.everywhere.backend.mapper;
+
+import com.everywhere.backend.model.dto.CounterRequestDto;
+import com.everywhere.backend.model.dto.CounterResponseDto;
+import com.everywhere.backend.model.entity.Counter;
+
+public class CounterMapper {
+
+    public static Counter toEntity(CounterRequestDto dto){
+        Counter counter = new Counter();
+        counter.setNombre(dto.getNombre());
+        counter.setEstado(Boolean.TRUE);
+        return counter;
+    }
+
+    public static CounterResponseDto toResponse(Counter entity){
+        CounterResponseDto dto = new CounterResponseDto();
+        dto.setId(entity.getId());
+        dto.setNombre(entity.getNombre());
+        dto.setEstado(entity.getEstado());
+        dto.setCodigo(entity.getCodigo());
+        return dto;
+    }
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/CounterRequestDto.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/CounterRequestDto.java
@@ -1,0 +1,10 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.Data;
+
+@Data
+public class CounterRequestDto {
+
+    private String nombre;
+    private String codigo;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/CounterResponseDto.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/CounterResponseDto.java
@@ -1,0 +1,14 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.Data;
+
+@Data
+public class CounterResponseDto {
+    private int id;
+
+    private String nombre;
+
+    private Boolean estado;
+
+    private String codigo;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/Counter.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/Counter.java
@@ -11,11 +11,14 @@ public class Counter {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "cou_id_int")
-    private Long id;
+    private int id;
 
     @Column(name = "cou_nom_vac", length = 150)
     private String nombre;
 
     @Column(name = "cou_est_bol")
     private Boolean estado;
+
+    @Column (name = "cou_cod_vac", length = 50)
+    private String codigo;
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/repository/CounterRepository.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/repository/CounterRepository.java
@@ -1,4 +1,13 @@
 package com.everywhere.backend.repository;
 
-public interface CounterRepository {
+import com.everywhere.backend.model.dto.CounterResponseDto;
+import com.everywhere.backend.model.entity.Counter;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CounterRepository extends JpaRepository<Counter, Integer> {
+    Optional<Counter> findByCodigo(String codigo);
+    Optional<Counter> findByNombreIgnoreCase(String nombre);
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/CounterService.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/CounterService.java
@@ -1,4 +1,26 @@
 package com.everywhere.backend.service;
 
+import com.everywhere.backend.model.dto.CounterRequestDto;
+import com.everywhere.backend.model.dto.CounterResponseDto;
+
+import java.util.List;
+import java.util.Optional;
+
 public interface CounterService {
+
+    CounterResponseDto create(CounterRequestDto dto);
+
+    CounterResponseDto update(CounterRequestDto dto);
+
+    CounterResponseDto activate(String codigo);
+
+    CounterResponseDto deactivate(String codigo);
+
+    Optional<CounterResponseDto> get(String codigo);
+    Optional<CounterResponseDto> getByName(String nombre);
+
+    List<CounterResponseDto> getAll();
+    List<CounterResponseDto> listActive();
+    List<CounterResponseDto> listInactive();
+
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/CounterServiceImpl.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/CounterServiceImpl.java
@@ -1,4 +1,96 @@
 package com.everywhere.backend.service.impl;
 
-public class CounterServiceImpl {
+import com.everywhere.backend.mapper.CounterMapper;
+import com.everywhere.backend.model.dto.CounterRequestDto;
+import com.everywhere.backend.model.dto.CounterResponseDto;
+import com.everywhere.backend.model.entity.Counter;
+import com.everywhere.backend.repository.CounterRepository;
+import com.everywhere.backend.service.CounterService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class CounterServiceImpl implements CounterService {
+
+    private final CounterRepository counterRepository;
+
+    // Constructor (si usas Lombok puedes poner @RequiredArgsConstructor)
+    public CounterServiceImpl(CounterRepository counterRepository) {
+        this.counterRepository = counterRepository;
+    }
+
+    @Override
+    public CounterResponseDto create(CounterRequestDto dto) {
+        Counter entity = CounterMapper.toEntity(dto);
+        entity.setCodigo(UUID.randomUUID().toString()); // genera el código
+        entity.setEstado(true);
+        Counter saved = counterRepository.save(entity);
+        return CounterMapper.toResponse(saved);
+    }
+
+    @Override
+    public CounterResponseDto update(CounterRequestDto dto) {
+        Counter entity = counterRepository.findByCodigo(dto.getCodigo())
+                .orElseThrow(() -> new RuntimeException("Counter no encontrado"));
+        entity.setNombre(dto.getNombre());
+        Counter updated = counterRepository.save(entity);
+        return CounterMapper.toResponse(updated);
+    }
+
+    @Override
+    public CounterResponseDto activate(String codigo) {
+        Counter entity = counterRepository.findByCodigo(codigo)
+                .orElseThrow(() -> new RuntimeException("Counter no encontrado"));
+        entity.setEstado(true);
+        return CounterMapper.toResponse(counterRepository.save(entity));
+    }
+
+    @Override
+    public CounterResponseDto deactivate(String codigo) {
+        Counter entity = counterRepository.findByCodigo(codigo)
+                .orElseThrow(() -> new RuntimeException("Counter no encontrado"));
+        entity.setEstado(false);
+        return CounterMapper.toResponse(counterRepository.save(entity));
+    }
+
+    @Override
+    public Optional<CounterResponseDto> get(String codigo) {
+        return counterRepository.findByCodigo(codigo)
+                .map(CounterMapper::toResponse);
+    }
+
+    @Override
+    public Optional<CounterResponseDto> getByName(String nombre) {
+        return counterRepository.findByNombreIgnoreCase(nombre)
+                .map(CounterMapper::toResponse);
+    }
+
+    @Override
+    public List<CounterResponseDto> getAll() {
+        return counterRepository.findAll()
+                .stream()
+                .map(CounterMapper::toResponse)
+                .toList();
+    }
+
+    @Override
+    public List<CounterResponseDto> listActive() {
+        return counterRepository.findAll()
+                .stream()
+                .filter(Counter::getEstado)
+                .map(CounterMapper::toResponse)
+                .toList();
+    }
+
+    @Override
+    public List<CounterResponseDto> listInactive() {
+        return counterRepository.findAll()
+                .stream()
+                .filter(c -> !c.getEstado())
+                .map(CounterMapper::toResponse)
+                .toList();
+    }
 }


### PR DESCRIPTION
En esta rama implementamos el CRUD para la entidad Counter

Se creó el controlador CounterController dentro del paquete com.everywhere.backend.api y se integró con el servicio CounterService para manejar la lógica de negocio a través de DTOs y el mapper correspondiente

Se agregaron los métodos necesarios para crear actualizar activar desactivar obtener un counter por código o nombre y listar todos los registros con filtros de estado activo o inactivo

Además se corrigieron detalles en el mapper para devolver el campo `codigo` generado automáticamente al momento de la creación

Las rutas disponibles son

- POST /counters para crear un nuevo counter  
- PUT /counters para actualizar un counter por código o nombre  
- PATCH /counters/activate para activar un counter enviando código o nombre en el body  
- PATCH /counters/desactivate para desactivar un counter enviando código o nombre en el body  
- GET /counters/search para obtener un counter enviando código
- GET /counters para listar todos los counters  
- GET /counters/activos para listar los counters activos  
- GET /counters/inactivos para listar los counters inactivos  

De esta forma el módulo Counter queda completo con endpoints que permiten tanto la gestión del ciclo de vida del recurso como las consultas filtradas
