### PR TITLE
Crud/estadoCotizacion

### DIFF
--- a/everywhere-backend/src/main/java/com/everywhere/backend/api/EstadosCotizacionController.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/api/EstadosCotizacionController.java
@@ -1,4 +1,53 @@
 package com.everywhere.backend.api;
 
+import com.everywhere.backend.model.dto.EstadoCotizacionRequestDto;
+import com.everywhere.backend.model.dto.EstadoCotizacionResponseDto;
+import com.everywhere.backend.service.EstadoCotizacionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/estados-cotizacion")
+@RequiredArgsConstructor
 public class EstadosCotizacionController {
+
+    private final EstadoCotizacionService estadoCotizacionService;
+
+    // Crear un estado
+    @PostMapping
+    public ResponseEntity<EstadoCotizacionResponseDto> create(@RequestBody EstadoCotizacionRequestDto request) {
+        return ResponseEntity.ok(estadoCotizacionService.create(request));
+    }
+
+    // Actualizar un estado (id por path, descripcion en body)
+    @PutMapping("/{id}")
+    public ResponseEntity<EstadoCotizacionResponseDto> update(
+            @PathVariable Integer id,
+            @RequestBody EstadoCotizacionRequestDto request) {
+        return ResponseEntity.ok(estadoCotizacionService.update(id, request));
+    }
+
+    // Obtener por id
+    @GetMapping("/{id}")
+    public ResponseEntity<EstadoCotizacionResponseDto> getById(@PathVariable Integer id) {
+        return estadoCotizacionService.getById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    // Listar todos
+    @GetMapping
+    public ResponseEntity<List<EstadoCotizacionResponseDto>> getAll() {
+        return ResponseEntity.ok(estadoCotizacionService.getAll());
+    }
+
+    // Eliminar por id
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+        estadoCotizacionService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/mapper/EstadoCotizacionMapper.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/mapper/EstadoCotizacionMapper.java
@@ -1,0 +1,21 @@
+package com.everywhere.backend.mapper;
+
+import com.everywhere.backend.model.dto.EstadoCotizacionRequestDto;
+import com.everywhere.backend.model.dto.EstadoCotizacionResponseDto;
+import com.everywhere.backend.model.entity.EstadoCotizacion;
+
+public class EstadoCotizacionMapper {
+
+    public static EstadoCotizacion toEntity(EstadoCotizacionRequestDto dto) {
+        EstadoCotizacion estadoCotizacion = new EstadoCotizacion();
+        estadoCotizacion.setDescripcion(dto.getDescripcion());
+        return estadoCotizacion;
+    }
+
+    public static EstadoCotizacionResponseDto toResponse(EstadoCotizacion entity) {
+        EstadoCotizacionResponseDto dto = new EstadoCotizacionResponseDto();
+        dto.setId(entity.getId());
+        dto.setDescripcion(entity.getDescripcion());
+        return dto;
+    }
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/EstadoCotizacionRequestDto.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/EstadoCotizacionRequestDto.java
@@ -1,0 +1,8 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.Data;
+
+@Data
+public class EstadoCotizacionRequestDto {
+    private String descripcion;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/EstadoCotizacionResponseDto.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/EstadoCotizacionResponseDto.java
@@ -1,0 +1,9 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.Data;
+
+@Data
+public class EstadoCotizacionResponseDto {
+    private int id;
+    private String descripcion;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/EstadoCotizacion.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/EstadoCotizacion.java
@@ -11,7 +11,7 @@ public class EstadoCotizacion {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "est_cot_id_int")
-    private Long id;
+    private int id;
 
     @Column(name = "est_cot_desc_vac", length = 200)
     private String descripcion;

--- a/everywhere-backend/src/main/java/com/everywhere/backend/repository/EstadoCotizacionRepository.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/repository/EstadoCotizacionRepository.java
@@ -1,4 +1,7 @@
 package com.everywhere.backend.repository;
 
-public interface EstadoCotizacionRepository {
+import com.everywhere.backend.model.entity.EstadoCotizacion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EstadoCotizacionRepository extends JpaRepository<EstadoCotizacion,Integer> {
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/EstadoCotizacionService.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/EstadoCotizacionService.java
@@ -1,0 +1,21 @@
+package com.everywhere.backend.service;
+
+import com.everywhere.backend.model.dto.EstadoCotizacionRequestDto;
+import com.everywhere.backend.model.dto.EstadoCotizacionResponseDto;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EstadoCotizacionService {
+
+    EstadoCotizacionResponseDto create(EstadoCotizacionRequestDto dto);
+
+    EstadoCotizacionResponseDto update(Integer id, EstadoCotizacionRequestDto dto);
+
+    Optional<EstadoCotizacionResponseDto> getById(Integer id);
+
+    List<EstadoCotizacionResponseDto> getAll();
+
+    void delete(Integer id);
+}
+

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/EstadoCotizacionServiceImpl.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/EstadoCotizacionServiceImpl.java
@@ -1,0 +1,60 @@
+package com.everywhere.backend.service.impl;
+
+import com.everywhere.backend.mapper.EstadoCotizacionMapper;
+import com.everywhere.backend.model.dto.EstadoCotizacionRequestDto;
+import com.everywhere.backend.model.dto.EstadoCotizacionResponseDto;
+import com.everywhere.backend.model.entity.EstadoCotizacion;
+import com.everywhere.backend.repository.EstadoCotizacionRepository;
+import com.everywhere.backend.service.EstadoCotizacionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EstadoCotizacionServiceImpl implements EstadoCotizacionService {
+
+    private final EstadoCotizacionRepository estadoCotizacionRepository;
+
+    @Override
+    public EstadoCotizacionResponseDto create(EstadoCotizacionRequestDto dto) {
+        EstadoCotizacion entity = EstadoCotizacionMapper.toEntity(dto);
+        EstadoCotizacion saved = estadoCotizacionRepository.save(entity);
+        return EstadoCotizacionMapper.toResponse(saved);
+    }
+
+    @Override
+    public EstadoCotizacionResponseDto update(Integer id, EstadoCotizacionRequestDto dto) {
+        EstadoCotizacion entity = estadoCotizacionRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Estado de Cotización no encontrado"));
+
+        entity.setDescripcion(dto.getDescripcion());
+        EstadoCotizacion updated = estadoCotizacionRepository.save(entity);
+
+        return EstadoCotizacionMapper.toResponse(updated);
+    }
+
+    @Override
+    public Optional<EstadoCotizacionResponseDto> getById(Integer id) {
+        return estadoCotizacionRepository.findById(id)
+                .map(EstadoCotizacionMapper::toResponse);
+    }
+
+    @Override
+    public List<EstadoCotizacionResponseDto> getAll() {
+        return estadoCotizacionRepository.findAll()
+                .stream()
+                .map(EstadoCotizacionMapper::toResponse)
+                .toList();
+    }
+
+    @Override
+    public void delete(Integer id) {
+        if (!estadoCotizacionRepository.existsById(id)) {
+            throw new RuntimeException("Estado de Cotización no encontrado");
+        }
+        estadoCotizacionRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
Descripción del PR  

En esta rama se implementó el CRUD para la entidad EstadoCotizacion  
Se añadieron DTOs, Mapper, Service, Repository, ServiceImpl y Controller para exponer los endpoints correspondientes.  

Se definieron las operaciones de creación, actualización, obtención por id, listado completo y eliminación.  
El flujo se maneja usando `EstadoCotizacionRequestDto` (solo descripción en el request) y `EstadoCotizacionResponseDto` (incluye id y descripción en la respuesta).  

Se incluyó el controlador `EstadosCotizacionController` en el paquete `com.everywhere.backend.api`, el cual expone las rutas necesarias para la gestión de estados de cotización.  

EndPoints  
- POST /estados-cotizacion → crear un nuevo estado de cotización  
- PUT /estados-cotizacion/{id} → actualizar un estado existente pasando el id en la ruta y la nueva descripción en el body  
- GET /estados-cotizacion/{id} → obtener un estado de cotización por su id  
- GET /estados-cotizacion → listar todos los estados de cotización  
- DELETE /estados-cotizacion/{id} → eliminar un estado de cotización por id  
