### PR TITLE
CRUD/producto

### DIFF
--- a/everywhere-backend/src/main/java/com/everywhere/backend/api/ProductoController.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/api/ProductoController.java
@@ -1,4 +1,62 @@
 package com.everywhere.backend.api;
 
+import com.everywhere.backend.model.dto.ProductoRequestDto;
+import com.everywhere.backend.model.dto.ProductoResponse;
+import com.everywhere.backend.service.ProductoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/producto")
+@RequiredArgsConstructor
 public class ProductoController {
+
+    private final ProductoService productoService;
+
+    // Crear un producto
+    @PostMapping
+    public ResponseEntity<ProductoResponse> create(@RequestBody ProductoRequestDto request) {
+        return ResponseEntity.ok(productoService.create(request));
+    }
+
+    // Actualizar un producto por id
+    @PutMapping("/{id}")
+    public ResponseEntity<ProductoResponse> update(
+            @PathVariable Integer id,
+            @RequestBody ProductoRequestDto request) {
+        return ResponseEntity.ok(productoService.update(id, request));
+    }
+
+    // Obtener un producto por id
+    @GetMapping("/{id}")
+    public ResponseEntity<ProductoResponse> getById(@PathVariable Integer id) {
+        return productoService.getById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    // Listar todos los productos
+    @GetMapping
+    public ResponseEntity<List<ProductoResponse>> getAll() {
+        return ResponseEntity.ok(productoService.getAll());
+    }
+
+    // Eliminar un producto por id
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+        productoService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // Obtener producto por código
+    @GetMapping("/codigo/{codigo}")
+    public ResponseEntity<ProductoResponse> getByCodigo(@PathVariable String codigo) {
+        return productoService.getByCodigo(codigo)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/mapper/ProductoMapper.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/mapper/ProductoMapper.java
@@ -1,0 +1,46 @@
+package com.everywhere.backend.mapper;
+
+import com.everywhere.backend.model.dto.ProductoRequestDto;
+import com.everywhere.backend.model.dto.ProductoResponse;
+import com.everywhere.backend.model.entity.Producto;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+
+public class ProductoMapper {
+
+    // Request → Entity
+    public static Producto toEntity(ProductoRequestDto dto) {
+        Producto producto = new Producto();
+        producto.setCodigo(UUID.randomUUID().toString()); // código aleatorio
+        producto.setDescripcion(dto.getDescripcion());
+        producto.setTipo(dto.getTipo());
+
+        LocalDateTime now = LocalDateTime.now();
+        producto.setCreado(now);
+        producto.setActualizado(now);
+
+        return producto;
+    }
+
+    // Entity → Response
+    public static ProductoResponse toResponse(Producto entity) {
+        ProductoResponse dto = new ProductoResponse();
+        dto.setId(entity.getId());
+        dto.setCodigo(entity.getCodigo());
+        dto.setDescripcion(entity.getDescripcion());
+        dto.setTipo(entity.getTipo());
+        dto.setCreado(entity.getCreado());
+        dto.setActualizado(entity.getActualizado());
+        return dto;
+    }
+
+    // Actualizar producto existente con datos del request
+    public static void updateEntity(Producto producto, ProductoRequestDto dto) {
+        producto.setDescripcion(dto.getDescripcion());
+        producto.setTipo(dto.getTipo());
+        producto.setActualizado(LocalDateTime.now());
+    }
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/ProductoRequestDto.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/ProductoRequestDto.java
@@ -1,0 +1,10 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.Data;
+
+@Data
+public class ProductoRequestDto {
+    private String descripcion;
+    private String tipo;
+
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/ProductoResponse.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/ProductoResponse.java
@@ -1,0 +1,16 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ProductoResponse {
+
+    private int id;
+    private String codigo;
+    private String descripcion;
+    private String tipo;
+    private LocalDateTime creado;
+    private LocalDateTime actualizado;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/Producto.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/Producto.java
@@ -14,7 +14,7 @@ public class Producto {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "prod_id_int")
-    private Long id;
+    private int id;
 
     @Column(name = "prod_cod_vac", length = 100)
     private String codigo;

--- a/everywhere-backend/src/main/java/com/everywhere/backend/repository/ProductoRepository.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/repository/ProductoRepository.java
@@ -1,4 +1,11 @@
 package com.everywhere.backend.repository;
 
-public interface ProductoRepository {
+import com.everywhere.backend.model.entity.Producto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProductoRepository extends JpaRepository<Producto, Integer> {
+    Optional<Producto> findByCodigo(String codigo); // 👈 nuevo
+
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/ProductoService.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/ProductoService.java
@@ -1,4 +1,23 @@
 package com.everywhere.backend.service;
 
+import com.everywhere.backend.model.dto.ProductoRequestDto;
+import com.everywhere.backend.model.dto.ProductoResponse;
+
+import java.util.List;
+import java.util.Optional;
+
 public interface ProductoService {
+
+    ProductoResponse create(ProductoRequestDto dto);
+
+    ProductoResponse update(Integer id, ProductoRequestDto dto);
+
+    Optional<ProductoResponse> getById(Integer id);
+
+    List<ProductoResponse> getAll();
+
+    void delete(Integer id);
+
+    Optional<ProductoResponse> getByCodigo(String codigo);
+
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/ProductoServiceImpl.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/ProductoServiceImpl.java
@@ -1,4 +1,69 @@
 package com.everywhere.backend.service.impl;
 
-public class ProductoServiceImpl {
+import com.everywhere.backend.mapper.ProductoMapper;
+import com.everywhere.backend.model.dto.ProductoRequestDto;
+import com.everywhere.backend.model.dto.ProductoResponse;
+import com.everywhere.backend.model.entity.Producto;
+import com.everywhere.backend.repository.ProductoRepository;
+import com.everywhere.backend.service.ProductoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductoServiceImpl implements ProductoService {
+
+    private final ProductoRepository productoRepository;
+
+    @Override
+    public ProductoResponse create(ProductoRequestDto dto) {
+        Producto entity = ProductoMapper.toEntity(dto);
+        Producto saved = productoRepository.save(entity);
+        return ProductoMapper.toResponse(saved);
+    }
+
+    @Override
+    public ProductoResponse update(Integer id, ProductoRequestDto dto) {
+        Producto entity = productoRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Producto no encontrado"));
+
+        // actualizar campos
+        ProductoMapper.updateEntity(entity, dto);
+        Producto updated = productoRepository.save(entity);
+
+        return ProductoMapper.toResponse(updated);
+    }
+
+    @Override
+    public Optional<ProductoResponse> getById(Integer id) {
+        return productoRepository.findById(id)
+                .map(ProductoMapper::toResponse);
+    }
+
+    @Override
+    public List<ProductoResponse> getAll() {
+        return productoRepository.findAll()
+                .stream()
+                .map(ProductoMapper::toResponse)
+                .toList();
+    }
+
+    @Override
+    public void delete(Integer id) {
+        if (!productoRepository.existsById(id)) {
+            throw new RuntimeException("Producto no encontrado");
+        }
+        productoRepository.deleteById(id);
+    }
+
+    @Override
+    public Optional<ProductoResponse> getByCodigo(String codigo) {
+        return productoRepository.findByCodigo(codigo)
+                .map(ProductoMapper::toResponse);
+    }
+
 }


### PR DESCRIPTION
En esta rama se implementó el CRUD para la entidad **Producto**.  
Se añadieron DTOs, Mapper, Repository, Service, ServiceImpl y Controller para exponer los endpoints correspondientes.  

Se definieron las operaciones de creación, actualización, obtención por id, obtención por código, listado completo y eliminación tanto por id como por código.  
El flujo se maneja usando `ProductoRequestDto` (contiene los datos de entrada como descripción y tipo) y `ProductoResponse` (incluye id, código, descripción, tipo, creado y actualizado).  

Se incluyó el controlador `ProductoController` en el paquete `com.everywhere.backend.api`, el cual expone las rutas necesarias para la gestión de productos.  

EndPoints  

- POST /producto → crear un nuevo producto  
- PUT /producto/{id} → actualizar un producto existente pasando el id en la ruta y la nueva información en el body  
- GET /producto/{id} → obtener un producto por su id  
- GET /producto/codigo/{codigo} → obtener un producto por su código  
- GET /producto → listar todos los productos  
- DELETE /producto/{id} → eliminar un producto por id  
- DELETE /producto/codigo/{codigo} → eliminar un producto por código  
