### PR TITLE
CRUD/carpeta

### DIFF
--- a/everywhere-backend/src/main/java/com/everywhere/backend/api/CarpetaController.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/api/CarpetaController.java
@@ -1,0 +1,112 @@
+package com.everywhere.backend.api;
+
+import com.everywhere.backend.model.dto.CarpetaRequestDto;
+import com.everywhere.backend.model.dto.CarpetaResponseDto;
+import com.everywhere.backend.service.CarpetaService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/carpeta")
+public class CarpetaController {
+
+    private final CarpetaService carpetaService;
+
+    public CarpetaController(CarpetaService carpetaService) {
+        this.carpetaService = carpetaService;
+    }
+
+    // Crear carpeta
+    @PostMapping
+    public ResponseEntity<CarpetaResponseDto> create(
+            @RequestBody CarpetaRequestDto dto,
+            @RequestParam(required = false) Integer carpetaPadreId) {
+
+        return ResponseEntity.ok(carpetaService.create(dto, carpetaPadreId));
+    }
+
+    // Buscar por ID
+    @GetMapping("/{id}")
+    public ResponseEntity<CarpetaResponseDto> findById(@PathVariable Integer id) {
+        return carpetaService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    // Listar todas
+    @GetMapping
+    public ResponseEntity<List<CarpetaResponseDto>> findAll() {
+        return ResponseEntity.ok(carpetaService.findAll());
+    }
+
+    // Actualizar
+    @PutMapping("/{id}")
+    public ResponseEntity<CarpetaResponseDto> update(
+            @PathVariable Integer id,
+            @RequestBody CarpetaRequestDto dto) {
+
+        return ResponseEntity.ok(carpetaService.update(id, dto));
+    }
+
+    // Eliminar
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+        carpetaService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // Listar por carpeta padre
+    @GetMapping("/padre/{carpetaPadreId}")
+    public ResponseEntity<List<CarpetaResponseDto>> findByCarpetaPadre(@PathVariable Integer carpetaPadreId) {
+        return ResponseEntity.ok(carpetaService.findByCarpetaPadreId(carpetaPadreId));
+    }
+
+    // Listar por nivel
+    @GetMapping("/nivel/{nivel}")
+    public ResponseEntity<List<CarpetaResponseDto>> findByNivel(@PathVariable Integer nivel) {
+        return ResponseEntity.ok(carpetaService.findByNivel(nivel));
+    }
+
+    // Listar por nombre
+    @GetMapping("/buscar")
+    public ResponseEntity<List<CarpetaResponseDto>> findByNombre(@RequestParam String nombre) {
+        return ResponseEntity.ok(carpetaService.findByNombre(nombre));
+    }
+
+    // Listar por año y mes
+    @GetMapping("/fecha/{mes}")
+    public ResponseEntity<List<CarpetaResponseDto>> findByMes(@PathVariable int mes) {
+        return ResponseEntity.ok(carpetaService.findByMes(mes));
+    }
+
+
+    // Listar por rango de fechas
+    @GetMapping("/fecha")
+    public ResponseEntity<List<CarpetaResponseDto>> findByRango(
+            @RequestParam LocalDate inicio,
+            @RequestParam LocalDate fin) {
+        return ResponseEntity.ok(carpetaService.findByFechaCreacionBetween(inicio, fin));
+    }
+
+    // Listar recientes
+    @GetMapping("/recientes")
+    public ResponseEntity<List<CarpetaResponseDto>> findRecent(@RequestParam(defaultValue = "5") int limit) {
+        return ResponseEntity.ok(carpetaService.findRecent(limit));
+    }
+
+    // Listar raíces (sin padre)
+    @GetMapping("/raices")
+    public ResponseEntity<List<CarpetaResponseDto>> findRaices() {
+        return ResponseEntity.ok(carpetaService.findRaices());
+    }
+
+    // Encontrar ruta de la carpeta
+    @GetMapping("/{id}/camino")
+    public ResponseEntity<List<CarpetaResponseDto>> findCamino(@PathVariable Integer id) {
+        return ResponseEntity.ok(carpetaService.findCamino(id));
+    }
+
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/mapper/CarpetaMapper.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/mapper/CarpetaMapper.java
@@ -1,0 +1,36 @@
+package com.everywhere.backend.mapper;
+
+import com.everywhere.backend.model.dto.CarpetaRequestDto;
+import com.everywhere.backend.model.dto.CarpetaResponseDto;
+import com.everywhere.backend.model.entity.Carpeta;
+
+public class CarpetaMapper {
+
+    public static Carpeta toEntity(CarpetaRequestDto carpetaRequestDto) {
+        if (carpetaRequestDto == null) {
+            return null;
+        }
+
+        Carpeta carpeta = new Carpeta();
+        carpeta.setNombre(carpetaRequestDto.getNombre());
+        carpeta.setDescripcion(carpetaRequestDto.getDescripcion());
+        return carpeta;
+    }
+
+    public static CarpetaResponseDto toResponse(Carpeta carpeta) {
+        if (carpeta == null) {
+            return null;
+        }
+        CarpetaResponseDto responseDto = new CarpetaResponseDto();
+        responseDto.setId(carpeta.getId());
+        responseDto.setNombre(carpeta.getNombre());
+        responseDto.setDescripcion(carpeta.getDescripcion());
+        responseDto.setCreado(carpeta.getCreado());
+        responseDto.setActualizado(carpeta.getActualizado());
+        responseDto.setNivel(carpeta.getNivel());
+        responseDto.setCarpetaPadreId(
+                carpeta.getCarpetaPadre() != null ? carpeta.getCarpetaPadre().getId() : null
+        );
+        return responseDto;
+    }
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/CarpetaRequestDto.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/CarpetaRequestDto.java
@@ -1,0 +1,9 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.Data;
+
+@Data
+public class CarpetaRequestDto {
+    private String nombre;
+    private String descripcion;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/CarpetaResponseDto.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/CarpetaResponseDto.java
@@ -1,0 +1,18 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class CarpetaResponseDto {
+
+    private int id;
+    private String nombre;
+    private String descripcion;
+    private LocalDateTime creado;
+    private LocalDateTime actualizado;
+    private int nivel;
+    private Integer carpetaPadreId;
+
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/Carpeta.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/Carpeta.java
@@ -12,7 +12,7 @@ public class Carpeta {
     @Id
     @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
     @Column(name="carp_id_int" )
-    private Long id;
+    private int id;
 
     @Column(name="carp_nom_vac", length=100 )
     private String nombre;
@@ -26,8 +26,11 @@ public class Carpeta {
     @Column(name="carp_upd_tmp" )
     private LocalDateTime actualizado;
 
+    @Column(name="carp_niv_int" )
+    private int nivel;
+
     @ManyToOne
-    @JoinColumn(name = "car´_id_padr_int")
+    @JoinColumn(name = "car_id_padr_int")
     private Carpeta carpetaPadre;
 
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/repository/CarpetaRepository.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/repository/CarpetaRepository.java
@@ -1,0 +1,30 @@
+package com.everywhere.backend.repository;
+
+import com.everywhere.backend.model.entity.Carpeta;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface CarpetaRepository extends JpaRepository<Carpeta, Integer> {
+    // Listar carpetas por hijo de un ID padre
+    List<Carpeta> findByCarpetaPadreId(Integer carpetaPadreId);
+
+    // Listar carpetas por nivel
+    List<Carpeta> findByNivel(Integer nivel);
+
+    // Listar carpetas por nombre (contiene, ignorando mayúsculas/minúsculas)
+    List<Carpeta> findByNombreContainingIgnoreCase(String nombre);
+
+    // Listar carpetas creadas en un rango de fechas (ejemplo: año/mes o entre dos días)
+    List<Carpeta> findByCreadoBetween(LocalDateTime inicio, LocalDateTime fin);
+
+    // Listar carpetas creadas en un rango, ordenadas por fecha ascendente
+    List<Carpeta> findByCreadoBetweenOrderByCreadoAsc(LocalDateTime inicio, LocalDateTime fin);
+
+    // Carpeta raíz (sin padre)
+    List<Carpeta> findByCarpetaPadreIsNull();
+
+    // Listar carpetas recientes (luego se limita con Pageable en el service)
+    List<Carpeta> findAllByOrderByCreadoDesc();
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/CarpetaService.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/CarpetaService.java
@@ -1,0 +1,42 @@
+package com.everywhere.backend.service;
+
+import com.everywhere.backend.model.dto.CarpetaRequestDto;
+import com.everywhere.backend.model.dto.CarpetaResponseDto;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface CarpetaService {
+
+    // CRUD
+    CarpetaResponseDto create(CarpetaRequestDto dto, Integer carpetaPadreId);
+    Optional<CarpetaResponseDto> findById(Integer id);
+    List<CarpetaResponseDto> findAll();
+    CarpetaResponseDto update(Integer id, CarpetaRequestDto dto);
+    void delete(Integer id);
+
+    // Listar carpetas por hijo de un ID padre
+    List<CarpetaResponseDto> findByCarpetaPadreId(Integer carpetaPadreId);
+
+    // Listar carpetas por nivel
+    List<CarpetaResponseDto> findByNivel(Integer nivel);
+
+    // Listar carpetas por nombre
+    List<CarpetaResponseDto> findByNombre(String nombre);
+
+    // Listar carpetas por año/mes
+    List<CarpetaResponseDto> findByMes(int mes);
+
+    // Listar carpetas por rango de días
+    List<CarpetaResponseDto> findByFechaCreacionBetween(LocalDate inicio, LocalDate fin);
+
+    // Buscar carpetas recientes
+    List<CarpetaResponseDto> findRecent(int limit);
+
+    // Buscar carpetas raíz
+    List<CarpetaResponseDto> findRaices();
+
+    // Lista la ruta por donde navegas
+    List<CarpetaResponseDto> findCamino(Integer carpetaId);
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/CarpetaServiceImpl.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/CarpetaServiceImpl.java
@@ -1,0 +1,169 @@
+package com.everywhere.backend.service.impl;
+
+import com.everywhere.backend.mapper.CarpetaMapper;
+import com.everywhere.backend.model.dto.CarpetaRequestDto;
+import com.everywhere.backend.model.dto.CarpetaResponseDto;
+import com.everywhere.backend.model.entity.Carpeta;
+import com.everywhere.backend.repository.CarpetaRepository;
+import com.everywhere.backend.service.CarpetaService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class CarpetaServiceImpl implements CarpetaService {
+
+    private final CarpetaRepository carpetaRepository;
+
+    public CarpetaServiceImpl(CarpetaRepository carpetaRepository) {
+        this.carpetaRepository = carpetaRepository;
+    }
+
+    @Override
+    public CarpetaResponseDto create(CarpetaRequestDto dto, Integer carpetaPadreId) {
+        Carpeta carpeta = CarpetaMapper.toEntity(dto);
+
+        if (carpetaPadreId != null) {
+            Carpeta carpetaPadre = carpetaRepository.findById(carpetaPadreId)
+                    .orElseThrow(() -> new RuntimeException("Carpeta padre no encontrada"));
+            carpeta.setCarpetaPadre(carpetaPadre);
+            carpeta.setNivel(carpetaPadre.getNivel() + 1);
+        } else {
+            carpeta.setNivel(0); // raíz
+        }
+
+        carpeta.setCreado(LocalDateTime.now());
+        carpeta.setActualizado(LocalDateTime.now());
+
+        Carpeta saved = carpetaRepository.save(carpeta);
+        return CarpetaMapper.toResponse(saved);
+    }
+
+    @Override
+    public Optional<CarpetaResponseDto> findById(Integer id) {
+        return carpetaRepository.findById(id).map(CarpetaMapper::toResponse);
+    }
+
+    @Override
+    public List<CarpetaResponseDto> findAll() {
+        return carpetaRepository.findAll()
+                .stream()
+                .map(CarpetaMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public CarpetaResponseDto update(Integer id, CarpetaRequestDto dto) {
+        Carpeta carpeta = carpetaRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Carpeta no encontrada"));
+
+        carpeta.setNombre(dto.getNombre());
+        carpeta.setDescripcion(dto.getDescripcion());
+        carpeta.setActualizado(LocalDateTime.now());
+
+        Carpeta updated = carpetaRepository.save(carpeta);
+        return CarpetaMapper.toResponse(updated);
+    }
+
+    @Override
+    public void delete(Integer id) {
+        if (!carpetaRepository.existsById(id)) {
+            throw new RuntimeException("Carpeta no encontrada");
+        }
+        carpetaRepository.deleteById(id);
+    }
+
+
+    @Override
+    public List<CarpetaResponseDto> findByCarpetaPadreId(Integer carpetaPadreId) {
+        return carpetaRepository.findByCarpetaPadreId(carpetaPadreId)
+                .stream()
+                .map(CarpetaMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CarpetaResponseDto> findByNivel(Integer nivel) {
+        return carpetaRepository.findByNivel(nivel)
+                .stream()
+                .map(CarpetaMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CarpetaResponseDto> findByNombre(String nombre) {
+        return carpetaRepository.findByNombreContainingIgnoreCase(nombre)
+                .stream()
+                .map(CarpetaMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CarpetaResponseDto> findByMes(int mes) {
+        int anioActual = LocalDate.now().getYear();
+        LocalDateTime inicio = LocalDate.of(anioActual, mes, 1).atStartOfDay();
+        LocalDateTime fin = inicio.plusMonths(1).minusSeconds(1);
+
+        return carpetaRepository.findByCreadoBetween(inicio, fin)
+                .stream()
+                .map(CarpetaMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+
+    @Override
+    public List<CarpetaResponseDto> findByFechaCreacionBetween(LocalDate inicio, LocalDate fin) {
+        LocalDateTime start = inicio.atStartOfDay();
+        LocalDateTime end = fin.plusDays(1).atStartOfDay().minusSeconds(1);
+        return carpetaRepository.findByCreadoBetweenOrderByCreadoAsc(start, end)
+                .stream()
+                .map(CarpetaMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CarpetaResponseDto> findRecent(int limit) {
+        return carpetaRepository.findAll(PageRequest.of(0, limit, Sort.by("creado").descending()))
+                .stream()
+                .map(CarpetaMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CarpetaResponseDto> findRaices() {
+        return carpetaRepository.findByCarpetaPadreIsNull()
+                .stream()
+                .map(CarpetaMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CarpetaResponseDto> findCamino(Integer carpetaId) {
+        Carpeta carpeta = carpetaRepository.findById(carpetaId)
+                .orElseThrow(() -> new RuntimeException("Carpeta no encontrada"));
+
+        List<Carpeta> camino = new ArrayList<>();
+
+        // Recorremos hacia arriba hasta la raíz
+        while (carpeta != null) {
+            camino.add(carpeta);
+            carpeta = carpeta.getCarpetaPadre();
+        }
+
+        // Invertimos para que quede desde la raíz hasta la carpeta actual
+        Collections.reverse(camino);
+
+        return camino.stream()
+                .map(CarpetaMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
## Carpeta - Endpoints implementados

- **POST** `/carpeta` → Crear carpeta (opcional: `?carpetaPadreId=`)
- **GET** `/carpeta/{id}` → Obtener carpeta por ID
- **GET** `/carpeta` → Listar todas las carpetas
- **PUT** `/carpeta/{id}` → Actualizar carpeta
- **DELETE** `/carpeta/{id}` → Eliminar carpeta (con cascada si tiene hijas)
- **GET** `/carpeta/padre/{carpetaPadreId}` → Listar carpetas hijas de un padre
- **GET** `/carpeta/nivel/{nivel}` → Listar carpetas por nivel
- **GET** `/carpeta/buscar?nombre=...` → Buscar carpetas por nombre
- **GET** `/carpeta/fecha/{mes}` → Listar carpetas creadas en un mes (año actual)
- **GET** `/carpeta/fecha?inicio=...&fin=...` → Listar carpetas por rango de fechas
- **GET** `/carpeta/recientes?limit=5` → Listar carpetas recientes
- **GET** `/carpeta/raices` → Listar carpetas raíz (sin padre)
- **GET** `/carpeta/{id}/camino` → Obtener el camino completo (breadcrumbs)

## Cambios realizados en la base de datos

1. Se corrigió el nombre de la columna de la clave foránea a:  
   `car_id_padr_int`

2. Se configuró la foreign key con `ON DELETE CASCADE`, lo que permite que al eliminar una carpeta padre se eliminen automáticamente todas sus carpetas hijas y descendientes.
