### PR TITLE
feat: creating crud and adding new relation on liquidacion entity

### DIFF
--- a/everywhere-backend/src/main/java/com/everywhere/backend/api/ObservacionLiquidacionController.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/api/ObservacionLiquidacionController.java
@@ -1,4 +1,55 @@
 package com.everywhere.backend.api;
 
+import com.everywhere.backend.model.dto.ObservacionLiquidacionRequestDTO;
+import com.everywhere.backend.model.dto.ObeservacionLiquidacionResponseDTO;
+import com.everywhere.backend.service.ObservacionLiquidacionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/observaciones-liquidacion")
+@RequiredArgsConstructor
 public class ObservacionLiquidacionController {
+
+    private final ObservacionLiquidacionService observacionLiquidacionService;
+
+    @GetMapping
+    public ResponseEntity<List<ObeservacionLiquidacionResponseDTO>> findAll() {
+        List<ObeservacionLiquidacionResponseDTO> observaciones = observacionLiquidacionService.findAll();
+        return ResponseEntity.ok(observaciones);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ObeservacionLiquidacionResponseDTO> findById(@PathVariable Long id) {
+        ObeservacionLiquidacionResponseDTO observacion = observacionLiquidacionService.findById(id);
+        return ResponseEntity.ok(observacion);
+    }
+
+    @PostMapping
+    public ResponseEntity<ObeservacionLiquidacionResponseDTO> create(@RequestBody ObservacionLiquidacionRequestDTO requestDTO) {
+        ObeservacionLiquidacionResponseDTO observacion = observacionLiquidacionService.save(requestDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).body(observacion);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ObeservacionLiquidacionResponseDTO> update(@PathVariable Long id, @RequestBody ObservacionLiquidacionRequestDTO requestDTO) {
+        ObeservacionLiquidacionResponseDTO observacion = observacionLiquidacionService.update(id, requestDTO);
+        return ResponseEntity.ok(observacion);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        observacionLiquidacionService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/liquidacion/{liquidacionId}")
+    public ResponseEntity<List<ObeservacionLiquidacionResponseDTO>> findByLiquidacionId(@PathVariable Integer liquidacionId) {
+        List<ObeservacionLiquidacionResponseDTO> observaciones = observacionLiquidacionService.findByLiquidacionId(liquidacionId);
+        return ResponseEntity.ok(observaciones);
+    }
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/mapper/ObservacionLiquidacionMapper.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/mapper/ObservacionLiquidacionMapper.java
@@ -1,0 +1,79 @@
+package com.everywhere.backend.mapper;
+
+import com.everywhere.backend.model.dto.ObservacionLiquidacionRequestDTO;
+import com.everywhere.backend.model.dto.ObeservacionLiquidacionResponseDTO;
+import com.everywhere.backend.model.entity.ObservacionLiquidacion;
+import com.everywhere.backend.model.entity.Liquidacion;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ObservacionLiquidacionMapper {
+
+    private final LiquidacionMapper liquidacionMapper;
+
+    public ObservacionLiquidacionMapper(LiquidacionMapper liquidacionMapper) {
+        this.liquidacionMapper = liquidacionMapper;
+    }
+
+    public ObservacionLiquidacion toEntity(ObservacionLiquidacionRequestDTO dto) {
+        if (dto == null) {
+            return null;
+        }
+
+        ObservacionLiquidacion entity = new ObservacionLiquidacion();
+        entity.setDescripcion(dto.getDescripcion());
+        entity.setValor(dto.getValor());
+        entity.setDocumento(dto.getDocumento());
+        entity.setNumeroDocumento(dto.getNumeroDocumento());
+
+        if (dto.getLiquidacionId() != null) {
+            Liquidacion liquidacion = new Liquidacion();
+            liquidacion.setId(dto.getLiquidacionId());
+            entity.setLiquidacion(liquidacion);
+        }
+
+        return entity;
+    }
+
+    public ObeservacionLiquidacionResponseDTO toResponseDTO(ObservacionLiquidacion entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        ObeservacionLiquidacionResponseDTO dto = new ObeservacionLiquidacionResponseDTO();
+        dto.setId(entity.getId());
+        dto.setDescripcion(entity.getDescripcion());
+        dto.setValor(entity.getValor());
+        dto.setDocumento(entity.getDocumento());
+        dto.setNumeroDocumento(entity.getNumeroDocumento());
+        dto.setCreado(entity.getCreado());
+        dto.setActualizado(entity.getActualizado());
+
+        if (entity.getLiquidacion() != null) {
+            dto.setLiquidacion(liquidacionMapper.toResponseDTO(entity.getLiquidacion()));
+        }
+
+        return dto;
+    }
+
+    public void updateEntityFromDTO(ObservacionLiquidacionRequestDTO dto, ObservacionLiquidacion entity) {
+        if (dto == null || entity == null) {
+            return;
+        }
+
+        // Solo actualizar campos que se envían (no son null)
+        if (dto.getDescripcion() != null) {
+            entity.setDescripcion(dto.getDescripcion());
+        }
+        if (dto.getValor() != null) {
+            entity.setValor(dto.getValor());
+        }
+        if (dto.getDocumento() != null) {
+            entity.setDocumento(dto.getDocumento());
+        }
+        if (dto.getNumeroDocumento() != null) {
+            entity.setNumeroDocumento(dto.getNumeroDocumento());
+        }
+
+    }
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/LiquidacionConDetallesResponseDTO.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/LiquidacionConDetallesResponseDTO.java
@@ -24,4 +24,7 @@ public class LiquidacionConDetallesResponseDTO {
 
     // Lista de detalles anidados (SIN la liquidación repetida)
     private List<DetalleLiquidacionSimpleDTO> detalles;
+
+    // Lista de observaciones anidadas (SIN la liquidación repetida)
+    private List<ObservacionLiquidacionSimpleDTO> observaciones;
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/ObeservacionLiquidacionResponseDTO.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/ObeservacionLiquidacionResponseDTO.java
@@ -1,0 +1,18 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.Data;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+public class ObeservacionLiquidacionResponseDTO {
+
+    private Long id;
+    private String descripcion;
+    private BigDecimal valor;
+    private String documento;
+    private String numeroDocumento;
+    private LocalDateTime creado;
+    private LocalDateTime actualizado;
+    private LiquidacionResponseDTO liquidacion;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/ObservacionLiquidacionRequestDTO.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/ObservacionLiquidacionRequestDTO.java
@@ -1,0 +1,14 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.Data;
+import java.math.BigDecimal;
+
+@Data
+public class ObservacionLiquidacionRequestDTO {
+
+    private String descripcion;
+    private BigDecimal valor;
+    private String documento;
+    private String numeroDocumento;
+    private Integer liquidacionId;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/ObservacionLiquidacionSimpleDTO.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/ObservacionLiquidacionSimpleDTO.java
@@ -1,0 +1,18 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.Data;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+public class ObservacionLiquidacionSimpleDTO {
+
+    private Long id;
+    private String descripcion;
+    private BigDecimal valor;
+    private String documento;
+    private String numeroDocumento;
+    private LocalDateTime creado;
+    private LocalDateTime actualizado;
+    // NO incluye la liquidación para evitar referencia circular
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/Liquidacion.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/Liquidacion.java
@@ -3,6 +3,7 @@ package com.everywhere.backend.model.entity;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Data;
 
 @Data
@@ -46,6 +47,9 @@ public class Liquidacion {
     @ManyToOne
     @JoinColumn(name = "prod_id_int", nullable = true)
     private Producto producto;
+
+    @OneToMany(mappedBy = "liquidacion")
+    private List<ObservacionLiquidacion> observacionesLiquidacion;
 
     @ManyToOne
     @JoinColumn(name = "form_id_int", nullable = true)

--- a/everywhere-backend/src/main/java/com/everywhere/backend/repository/LiquidacionRepository.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/repository/LiquidacionRepository.java
@@ -16,7 +16,8 @@ public interface LiquidacionRepository extends JpaRepository<Liquidacion, Intege
            "LEFT JOIN FETCH l.producto " +
            "LEFT JOIN FETCH l.formaPago " +
            "LEFT JOIN FETCH l.cotizacion " +
-           "LEFT JOIN FETCH l.carpeta")
+           "LEFT JOIN FETCH l.carpeta " +
+           "LEFT JOIN FETCH l.observacionesLiquidacion")
     List<Liquidacion> findAllWithRelations();
 
     @Query("SELECT l FROM Liquidacion l " +
@@ -24,6 +25,7 @@ public interface LiquidacionRepository extends JpaRepository<Liquidacion, Intege
            "LEFT JOIN FETCH l.formaPago " +
            "LEFT JOIN FETCH l.cotizacion " +
            "LEFT JOIN FETCH l.carpeta " +
+           "LEFT JOIN FETCH l.observacionesLiquidacion " +
            "WHERE l.id = :id")
     Optional<Liquidacion> findByIdWithRelations(@Param("id") Integer id);
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/repository/ObservacionLiquidacionRepository.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/repository/ObservacionLiquidacionRepository.java
@@ -1,4 +1,36 @@
 package com.everywhere.backend.repository;
 
-public interface ObservacionLiquidacionRepository {
+import com.everywhere.backend.model.entity.ObservacionLiquidacion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ObservacionLiquidacionRepository extends JpaRepository<ObservacionLiquidacion, Long> {
+
+    @Query("SELECT o FROM ObservacionLiquidacion o " +
+           "LEFT JOIN FETCH o.liquidacion l " +
+           "LEFT JOIN FETCH l.producto " +
+           "LEFT JOIN FETCH l.formaPago " +
+           "LEFT JOIN FETCH l.cotizacion " +
+           "LEFT JOIN FETCH l.carpeta " +
+           "WHERE o.id = :id")
+    Optional<ObservacionLiquidacion> findByIdWithLiquidacion(@Param("id") Long id);
+
+    @Query("SELECT o FROM ObservacionLiquidacion o " +
+           "LEFT JOIN FETCH o.liquidacion l " +
+           "LEFT JOIN FETCH l.producto " +
+           "LEFT JOIN FETCH l.formaPago " +
+           "LEFT JOIN FETCH l.cotizacion " +
+           "LEFT JOIN FETCH l.carpeta")
+    List<ObservacionLiquidacion> findAllWithLiquidacion();
+
+    @Query("SELECT o FROM ObservacionLiquidacion o " +
+           "LEFT JOIN FETCH o.liquidacion " +
+           "WHERE o.liquidacion.id = :liquidacionId")
+    List<ObservacionLiquidacion> findByLiquidacionId(@Param("liquidacionId") Integer liquidacionId);
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/ObservacionLiquidacionService.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/ObservacionLiquidacionService.java
@@ -1,4 +1,16 @@
 package com.everywhere.backend.service;
 
+import com.everywhere.backend.model.dto.ObservacionLiquidacionRequestDTO;
+import com.everywhere.backend.model.dto.ObeservacionLiquidacionResponseDTO;
+
+import java.util.List;
+
 public interface ObservacionLiquidacionService {
+
+    List<ObeservacionLiquidacionResponseDTO> findAll();
+    ObeservacionLiquidacionResponseDTO findById(Long id);
+    ObeservacionLiquidacionResponseDTO save(ObservacionLiquidacionRequestDTO requestDTO);
+    ObeservacionLiquidacionResponseDTO update(Long id, ObservacionLiquidacionRequestDTO requestDTO);
+    void deleteById(Long id);
+    List<ObeservacionLiquidacionResponseDTO> findByLiquidacionId(Integer liquidacionId);
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/ObservacionLiquidacionServiceImpl.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/ObservacionLiquidacionServiceImpl.java
@@ -1,4 +1,78 @@
 package com.everywhere.backend.service.impl;
 
-public class ObservacionLiquidacionServiceImpl {
+import com.everywhere.backend.model.dto.ObservacionLiquidacionRequestDTO;
+import com.everywhere.backend.model.dto.ObeservacionLiquidacionResponseDTO;
+import com.everywhere.backend.model.entity.ObservacionLiquidacion;
+import com.everywhere.backend.repository.ObservacionLiquidacionRepository;
+import com.everywhere.backend.service.ObservacionLiquidacionService;
+import com.everywhere.backend.exceptions.ResourceNotFoundException;
+import com.everywhere.backend.mapper.ObservacionLiquidacionMapper;
+import org.springframework.stereotype.Service;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ObservacionLiquidacionServiceImpl implements ObservacionLiquidacionService {
+
+    private final ObservacionLiquidacionRepository observacionLiquidacionRepository;
+    private final ObservacionLiquidacionMapper observacionLiquidacionMapper;
+
+    @Override
+    public List<ObeservacionLiquidacionResponseDTO> findAll() {
+        return observacionLiquidacionRepository.findAllWithLiquidacion().stream()
+                .map(observacionLiquidacionMapper::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public ObeservacionLiquidacionResponseDTO findById(Long id) {
+        ObservacionLiquidacion observacion = observacionLiquidacionRepository.findByIdWithLiquidacion(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Observación de liquidación no encontrada con ID: " + id));
+        return observacionLiquidacionMapper.toResponseDTO(observacion);
+    }
+
+    @Override
+    public ObeservacionLiquidacionResponseDTO save(ObservacionLiquidacionRequestDTO requestDTO) {
+        ObservacionLiquidacion observacion = observacionLiquidacionMapper.toEntity(requestDTO);
+        observacion = observacionLiquidacionRepository.save(observacion);
+
+        // Fetch la entidad completa con relaciones después de guardar
+        ObservacionLiquidacion observacionCompleta = observacionLiquidacionRepository.findByIdWithLiquidacion(observacion.getId())
+                .orElse(observacion);
+
+        return observacionLiquidacionMapper.toResponseDTO(observacionCompleta);
+    }
+
+    @Override
+    public ObeservacionLiquidacionResponseDTO update(Long id, ObservacionLiquidacionRequestDTO requestDTO) {
+        ObservacionLiquidacion existingObservacion = observacionLiquidacionRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Observación de liquidación no encontrada con ID: " + id));
+
+        observacionLiquidacionMapper.updateEntityFromDTO(requestDTO, existingObservacion);
+        existingObservacion = observacionLiquidacionRepository.save(existingObservacion);
+
+        // Fetch la entidad completa con relaciones después de actualizar
+        ObservacionLiquidacion observacionCompleta = observacionLiquidacionRepository.findByIdWithLiquidacion(existingObservacion.getId())
+                .orElse(existingObservacion);
+
+        return observacionLiquidacionMapper.toResponseDTO(observacionCompleta);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        if (!observacionLiquidacionRepository.existsById(id)) {
+            throw new ResourceNotFoundException("Observación de liquidación no encontrada con ID: " + id);
+        }
+        observacionLiquidacionRepository.deleteById(id);
+    }
+
+    @Override
+    public List<ObeservacionLiquidacionResponseDTO> findByLiquidacionId(Integer liquidacionId) {
+        return observacionLiquidacionRepository.findByLiquidacionId(liquidacionId).stream()
+                .map(observacionLiquidacionMapper::toResponseDTO)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
 **Integración de la función ObservaciónLiquidación**

* Se ha añadido `ObservacionLiquidacionController` con puntos finales para listar, recuperar, crear, actualizar, eliminar y consultar por `liquidacionId` para observaciones de liquidación.
* Se han creado DTO: `ObservacionLiquidacionRequestDTO`, `ObeservacionLiquidacionResponseDTO` y `ObservacionLiquidacionSimpleDTO` para solicitudes/respuestas y representaciones anidadas. 
* Se ha añadido `ObservacionLiquidacionMapper` para convertir entre entidades y DTO, incluyendo lógica de actualización que solo cambia los campos no nulos.
* Se ha implementado `ObservacionLiquidacionRepository` con consultas personalizadas para la recuperación por ID, todo y por `liquidacionId`, incluidas las entidades relacionadas.
* Se ha definido la interfaz `ObservacionLiquidacionService` para operaciones CRUD y consultas por `liquidacionId`.

**Mejoras en la entidad y el repositorio Liquidacion**

* Se ha añadido una relación `List<ObservacionLiquidacion>` a `Liquidacion` y se han actualizado las consultas del repositorio para recuperar de forma inmediata las observaciones asociadas. 
* Se ha ampliado `LiquidacionConDetallesResponseDTO` para incluir una lista de observaciones anidadas.

**Mejoras en el mapeador y el código base**

* Se ha refactorizado `DetalleLiquidacionMapper` para utilizar `Optional` y obtener un mapeo más limpio de las entidades relacionadas, y se ha mejorado la lógica de actualización para que solo se actualicen los campos y las relaciones cuando se proporcionen.

**Cambios en la implementación del servicio**

* Se han actualizado las implementaciones del servicio para admitir la nueva función de observaciones, incluidas nuevas importaciones y puntos de integración. 