### PR TITLE
feat: adding spring security

### DIFF
--- a/everywhere-backend/pom.xml
+++ b/everywhere-backend/pom.xml
@@ -76,11 +76,14 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- ========== SPRING SECURITY ========== -->
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>me.paulschwarz</groupId>
             <artifactId>spring-dotenv</artifactId>
@@ -97,6 +100,40 @@
             <version>13.0</version>
             <scope>compile</scope>
         </dependency>
+
+        <!-- ========== SPRING BOOT CORE ========== -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- ========== JWT (JSON Web Token) ========== -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/everywhere-backend/src/main/java/com/everywhere/backend/api/AuthController.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/api/AuthController.java
@@ -1,0 +1,27 @@
+package com.everywhere.backend.api;
+
+import com.everywhere.backend.model.dto.AuthResponseDTO;
+import com.everywhere.backend.model.dto.LoginDTO;
+import com.everywhere.backend.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final UserService userService;
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponseDTO> login(@Valid @RequestBody LoginDTO loginDTO) {
+        AuthResponseDTO authResponseDTO = userService.login(loginDTO);
+        return new ResponseEntity<>(authResponseDTO, HttpStatus.OK);
+    }
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/config/WebSecurityConfig.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/config/WebSecurityConfig.java
@@ -1,0 +1,77 @@
+package com.everywhere.backend.config;
+
+import com.everywhere.backend.security.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+public class WebSecurityConfig {
+
+    private final TokenProvider tokenProvider;
+    private final JWTFilter jwtRequestFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final CustomUserDetailsService userDetailsService;
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+
+                .authorizeHttpRequests(authorize -> authorize
+                        // TODO: Permitir acceso público a las rutas de login, registro y endpoints públicos como Swagger UI
+                        .requestMatchers(antMatcher("/auth/**")).permitAll()
+                        .requestMatchers(antMatcher("/swagger-ui/**")).permitAll()
+                        .requestMatchers(antMatcher("/v3/api-docs/**")).permitAll()
+                        .requestMatchers(antMatcher("/swagger-resources/**")).permitAll()
+                        .requestMatchers(antMatcher("/webjars/**")).permitAll()
+                        // TODO: Cualquier otra solicitud requiere autenticación (JWT u otra autenticación configurada)
+                        .anyRequest().authenticated()
+                )
+
+                // TODO: Permite la autenticación básica (para testing con Postman, por ejemplo)
+                //.httpBasic(Customizer.withDefaults())
+                // TODO: Desactiva el formulario de inicio de sesión predeterminado, ya que se usará JWT
+                .formLogin(AbstractHttpConfigurer::disable)
+                // TODO: Configura el manejo de excepciones para autenticación. Usa JwtAuthenticationEntryPoint para manejar errores 401 (no autorizado)
+                .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                // TODO: Configura la política de sesiones como "sin estado" (stateless), ya que JWT maneja la autenticación, no las sesiones de servidor
+                .sessionManagement(h -> h.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // TODO: Agrega la configuración para JWT en el filtro antes de los filtros predeterminados de Spring Security
+                .with(new JWTConfigurer(tokenProvider), Customizer.withDefaults());
+
+        // TODO: Añadir el JWTFilter antes del filtro de autenticación de nombre de usuario/contraseña.
+        //  Esto permite que el JWTFilter valide el token antes de la autenticación
+        http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        // TODO: Proporciona el AuthenticationManager que gestionará la autenticación basada en los detalles de usuario y contraseña
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/exceptions/CustomErrorResponse.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/exceptions/CustomErrorResponse.java
@@ -1,0 +1,17 @@
+package com.everywhere.backend.exceptions;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class CustomErrorResponse {
+    private LocalDateTime timestamp;
+    private String message;
+    private String details;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/mapper/UserMapper.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/mapper/UserMapper.java
@@ -1,0 +1,46 @@
+package com.everywhere.backend.mapper;
+
+import com.everywhere.backend.model.dto.*;
+import com.everywhere.backend.model.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserMapper {
+    private final ModelMapper modelMapper;
+
+    /**
+     * Convierte LoginDTO a User entity (para autenticación)
+     */
+    public User toUserEntity(LoginDTO loginDTO) {
+        return modelMapper.map(loginDTO, User.class);
+    }
+
+    /**
+     * Convierte User entity a AuthResponseDTO (respuesta de login con JWT)
+     */
+    public AuthResponseDTO toAuthResponseDTO(User user, String token) {
+        AuthResponseDTO authResponseDTO = new AuthResponseDTO();
+        authResponseDTO.setId(user.getId());
+        authResponseDTO.setToken(token);
+        authResponseDTO.setRole(user.getRole().getName());
+
+        // Como los usuarios se crean manualmente en BD, usar datos básicos
+        authResponseDTO.setName(user.getEmail()); // Usar email como nombre temporal
+
+        return authResponseDTO;
+    }
+
+    /**
+     * Convierte User básico a DTO simple
+     */
+    public UserBasicDTO toUserBasicDTO(User user) {
+        UserBasicDTO userBasicDTO = new UserBasicDTO();
+        userBasicDTO.setId(user.getId());
+        userBasicDTO.setEmail(user.getEmail());
+        userBasicDTO.setName(user.getEmail()); // Usar email como identificador
+        return userBasicDTO;
+    }
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/AuthResponseDTO.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/AuthResponseDTO.java
@@ -1,0 +1,11 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.Data;
+
+@Data
+public class AuthResponseDTO {
+    private Integer id;
+    private String token;
+    private String name;
+    private String role;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/LoginDTO.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/LoginDTO.java
@@ -1,0 +1,14 @@
+package com.everywhere.backend.model.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class LoginDTO {
+    @NotBlank(message = "El correo electronico es obligatorio")
+    @Email(message = "El correo electronico no es valido" )
+    private String email;
+    @NotBlank(message = "La contraseña es obligatoria")
+    private String password;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/UserBasicDTO.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/UserBasicDTO.java
@@ -1,0 +1,14 @@
+package com.everywhere.backend.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserBasicDTO {
+    private Integer id;
+    private String name;
+    private String email;
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/Role.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/Role.java
@@ -13,11 +13,11 @@ public class Role {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "role_id")
+    @Column(name = "rol_id")
     private Integer id;
 
     @Column(name = "rol_nam_vc", length = 100)
-    private String nombre;
+    private String name;
 
     @CreationTimestamp
     @Column(name = "prov_cre_tmp", updatable = false)

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/User.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/User.java
@@ -9,7 +9,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Data
 @Entity
 @Table(name = "usuarios")
-public class Usuario {
+public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,8 +33,8 @@ public class Usuario {
     @Column(name = "prov_upd_tmp")
     private LocalDateTime actualizado;
 
-    @ManyToOne
-    @JoinColumn(name = "role_id", nullable = false)
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "rol_id", nullable = false)
     private Role role;
 
 }

--- a/everywhere-backend/src/main/java/com/everywhere/backend/repository/UserRepository.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/repository/UserRepository.java
@@ -1,0 +1,24 @@
+package com.everywhere.backend.repository;
+
+import com.everywhere.backend.model.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Integer> {
+    Optional<User> findByEmail(String email);
+
+    @Query("SELECT u FROM User u WHERE u.email = :email")
+    User findByEmailQuery(@Param("email") String email);
+
+    @Query("SELECT COUNT(u) > 0 FROM User u WHERE u.email = :email")
+    boolean existsByEmail(@Param("email") String email);
+
+    @Query("SELECT u.role.name FROM User u WHERE u.id = :userId")
+    String findRoleByUserId(@Param("userId") Integer userId);
+
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/security/CustomUserDetailsService.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/security/CustomUserDetailsService.java
@@ -1,0 +1,36 @@
+package com.everywhere.backend.security;
+
+import com.everywhere.backend.model.entity.User;
+import com.everywhere.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email).orElseThrow(() ->
+                new UsernameNotFoundException("Usuario no encontrado con el email : "+email));
+
+        GrantedAuthority authority = new SimpleGrantedAuthority(user.getRole().getName());
+
+        return new UserPrincipal(
+                user.getId(),
+                user.getEmail(),
+                user.getPassword(),
+                Collections.singletonList(authority),
+                user
+        );
+    }
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/security/JWTConfigurer.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/security/JWTConfigurer.java
@@ -1,0 +1,27 @@
+package com.everywhere.backend.security;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@AllArgsConstructor
+@Configuration
+public class JWTConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void configure(final HttpSecurity http) throws Exception {
+
+        JWTFilter jwtFilter = new JWTFilter(tokenProvider);
+
+        http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/security/JWTFilter.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/security/JWTFilter.java
@@ -1,0 +1,51 @@
+package com.everywhere.backend.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.apache.catalina.connector.Request;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+import java.io.IOException;
+
+
+@Component
+@AllArgsConstructor
+public class JWTFilter extends GenericFilterBean {
+
+    private  final TokenProvider tokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+
+        String bearerToken = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
+
+        // TODO: Verificar si el token no es nulo/vacío y si empieza con el prefijo "Bearer "
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            // Eliminar el prefijo "Bearer " para obtener solo el token
+            String token = bearerToken.substring(7);
+
+            // TODO: Utilizar el TokenProvider para obtener la autenticación a partir del token JWT
+            Authentication authentication = tokenProvider.getAuthentication(token);
+
+            // TODO: Establecer la autenticación en el contexto de seguridad de Spring para la solicitud actual
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        // TODO: Continuar con la cadena de filtros, permitiendo que la solicitud siga su curso
+        chain.doFilter(request, response);
+    }
+
+}
+

--- a/everywhere-backend/src/main/java/com/everywhere/backend/security/JwtAuthenticationEntryPoint.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,53 @@
+package com.everywhere.backend.security;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.everywhere.backend.exceptions.CustomErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+
+        // TODO: Obtener el mensaje de error si es que existe, de lo contrario establecer un mensaje por defecto
+        String exceptionMsg = (String) request.getAttribute("exception");
+
+        if (exceptionMsg == null) {
+            exceptionMsg = "Token not found or invalid"; // Mensaje de error por defecto
+        }
+
+        // TODO: Crear un objeto de error personalizado con la fecha, mensaje de error y la URI de la solicitud
+        CustomErrorResponse errorResponse = new CustomErrorResponse(LocalDateTime.now(), exceptionMsg, request.getRequestURI());
+
+        // TODO: Establecer el estado HTTP de respuesta como "401 Unauthorized"
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+        // TODO: Escribir la respuesta de error en formato JSON en el cuerpo de la respuesta
+        response.getWriter().write(convertObjectToJson(errorResponse));
+
+        // TODO: Establecer el tipo de contenido de la respuesta como JSON
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    }
+
+    // Método auxiliar para convertir el objeto de error en un JSON para incluirlo en la respuesta HTTP
+    private String convertObjectToJson(Object object) throws JsonProcessingException {
+        if (object == null) {
+            return null;
+        }
+        // TODO: Convertir el objeto en una cadena JSON utilizando ObjectMapper de Jackson
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules(); // Esto registra módulos adicionales si es necesario (por ejemplo, soporte de fechas)
+        return mapper.writeValueAsString(object); // Devolver el objeto convertido a JSON
+    }
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/security/TokenProvider.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/security/TokenProvider.java
@@ -1,0 +1,101 @@
+package com.everywhere.backend.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+@Data
+public class TokenProvider {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.validity-in-seconds}")
+    private long jwtValidityInSeconds;
+
+    private Key key;
+
+    private JwtParser jwtParser;
+
+    @PostConstruct
+    public void init() {
+        // Generar la clave para firmar el JWT a partir del secreto configurado
+        key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtSecret));
+
+        // Inicializar el parser JWT con la clave generada para firmar y validar tokens
+        jwtParser = Jwts
+                .parserBuilder()
+                .setSigningKey(key)
+                .build();
+    }
+
+    // TODO: Método para crear el token JWT con los detalles del usuario autenticado
+    public String createAccessToken(Authentication authentication) {
+        // TODO: Obtener el email o nombre del usuario autenticado
+        String email = authentication.getName();
+
+        // TODO: Obtener el rol del usuario desde el objeto de autenticación
+        String role = authentication
+                .getAuthorities()
+                .stream()
+                .findFirst()
+                .orElseThrow(NullPointerException::new)
+                .getAuthority();
+
+        // TODO: Construir y firmar el token JWT que incluye el rol y el email
+        return Jwts
+                .builder()
+                .setSubject(email)  // El sujeto del token es el email o nombre de usuario
+                .claim("role", role)  // El rol se incluye como claim en el token
+                .signWith(key, SignatureAlgorithm.HS512)  // Firmar el token con el algoritmo HS512 y la clave
+                .setExpiration(new Date(System.currentTimeMillis() + jwtValidityInSeconds * 1000))  // Configurar la fecha de expiración del token
+                .compact();
+    }
+
+    // TODO: Método para obtener la autenticación a partir del token JWT
+    public Authentication getAuthentication(String token) {
+        // TODO: Extraer los claims (datos) del token JWT
+        Claims claims = jwtParser.parseClaimsJws(token).getBody();
+
+        // TODO: Obtener el rol del token
+        String role = claims.get("role").toString();
+
+        // TODO: Crear la lista de autoridades (roles) para el usuario
+        List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
+
+        // TODO: El principal del contexto de seguridad será el email (subject) extraído del token
+        User principal = new User(claims.getSubject(), "", authorities);
+
+        // TODO: Crear el objeto de autenticación con los detalles del usuario
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    // TODO: Método para validar el token JWT (si está correctamente firmado y no ha expirado)
+    public boolean validateToken(String token) {
+        try {
+            // TODO: Parsear el token JWT para verificar su validez
+            jwtParser.parseClaimsJws(token);
+            return true;  // El token es válido
+        } catch (JwtException e) {
+            return false;  // El token no es válido
+        }
+    }
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/security/UserPrincipal.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/security/UserPrincipal.java
@@ -1,0 +1,37 @@
+package com.everywhere.backend.security;
+
+import com.everywhere.backend.model.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPrincipal implements UserDetails {
+    private Integer id;
+    private String email;
+    private String password;
+    private Collection<? extends GrantedAuthority> authorities;
+    private User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+}
+

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/UserService.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/UserService.java
@@ -1,0 +1,19 @@
+package com.everywhere.backend.service;
+
+import com.everywhere.backend.model.dto.*;
+import com.everywhere.backend.model.entity.User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+@Service
+public interface UserService {
+
+    //Autenticar el login
+    AuthResponseDTO login(LoginDTO loginDTO);
+    Integer getAuthenticatedUserIdFromJWT();
+
+    User getUserbyId(Integer userId);
+    List<User> getAllUsers();
+    UserBasicDTO getUserBasicInfo(Integer userId);
+}
+

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/UserServiceImpl.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/UserServiceImpl.java
@@ -1,0 +1,91 @@
+package com.everywhere.backend.service.impl;
+
+import com.everywhere.backend.exceptions.ResourceNotFoundException;
+import io.jsonwebtoken.Claims;
+import com.everywhere.backend.mapper.UserMapper;
+import com.everywhere.backend.model.dto.*;
+
+import com.everywhere.backend.model.entity.User;
+import com.everywhere.backend.repository.UserRepository;
+import com.everywhere.backend.security.TokenProvider;
+import com.everywhere.backend.security.UserPrincipal;
+import com.everywhere.backend.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+    private final AuthenticationManager authenticationManager;
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public AuthResponseDTO login(LoginDTO loginDTO) {
+        // Autenticar usuario
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        loginDTO.getEmail(),
+                        loginDTO.getPassword()
+                )
+        );
+
+        // Obtener datos del usuario autenticado
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+        User user = userPrincipal.getUser();
+
+        // Generar token JWT
+        String token = tokenProvider.createAccessToken(authentication);
+
+        // Retornar respuesta con token
+        return userMapper.toAuthResponseDTO(user, token);
+    }
+
+    @Override
+    public Integer getAuthenticatedUserIdFromJWT() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.isAuthenticated()) {
+            String token = (String) authentication.getCredentials();
+
+            // Extraer email del token
+            Claims claims = tokenProvider.getJwtParser().parseClaimsJws(token).getBody();
+            String email = claims.getSubject();
+
+            // Buscar usuario por email
+            User user = userRepository.findByEmail(email).orElse(null);
+            return user != null ? user.getId() : null;
+        }
+        return null;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public User getUserbyId(Integer userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Usuario no encontrado con ID: " + userId));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserBasicDTO getUserBasicInfo(Integer userId) {
+        User user = getUserbyId(userId);
+        return userMapper.toUserBasicDTO(user);
+    }
+
+}

--- a/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/UsuarioServiceImpl.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/service/impl/UsuarioServiceImpl.java
@@ -1,4 +1,0 @@
-package com.everywhere.backend.service.impl;
-
-public class UsuarioServiceImpl {
-}

--- a/everywhere-backend/src/main/resources/application.properties
+++ b/everywhere-backend/src/main/resources/application.properties
@@ -12,4 +12,7 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
+#spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
+
+jwt.secret=${JWT_SECRET}
+jwt.validity-in-seconds=2592000


### PR DESCRIPTION
This pull request introduces authentication and authorization features to the backend, primarily by integrating Spring Security and JWT-based authentication. It adds new dependencies, configures security, creates necessary DTOs and mappers, and refactors entity names for clarity and consistency.

**Authentication & Security Integration**
* Added Spring Security and JWT dependencies to `pom.xml` to enable user authentication and token management. 
* Implemented `WebSecurityConfig`, which configures HTTP security, permits public access to authentication and documentation endpoints, enforces stateless sessions, and integrates JWT filters for request validation.
* Added JWT-related classes: `JWTFilter` for token validation, `JWTConfigurer` for filter registration, and `JwtAuthenticationEntryPoint` for custom error responses on unauthorized access.
* Created `CustomUserDetailsService` to load user details from the database for authentication.

**User Authentication API**
* Added `AuthController` with a `/auth/login` endpoint that validates credentials and returns a JWT in the response.

**Model & Mapping Updates**
* Refactored entity names: renamed `Usuario` to `User`, updated role and column names for consistency, and adjusted relationships. 
* Added DTOs for authentication (`LoginDTO`, `AuthResponseDTO`, `UserBasicDTO`) and a `UserMapper` for converting between entities and DTOs.

**Repository Enhancements**
* Created `UserRepository` with methods for finding users by email, checking existence, and retrieving roles.

**Error Handling**
* Added `CustomErrorResponse` class for standardized error responses in authentication flows.