### PR TITLE
feat: adding boolean column so the user can know if the person its the one who calls, and the other column set a category to the natural person

### DIFF
--- a/everywhere-backend/src/main/java/com/everywhere/backend/mapper/PersonaNaturalMapper.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/mapper/PersonaNaturalMapper.java
@@ -39,6 +39,12 @@ public class PersonaNaturalMapper {
         if (dto.getApellidos() != null) {
             entity.setApellidos(dto.getApellidos());
         }
+        if (dto.getCliente() != null) {
+            entity.setCliente(dto.getCliente());
+        }
+        if (dto.getCategoria() != null) {
+            entity.setCategoria(dto.getCategoria());
+        }
 
         // Actualizar persona base si existe
         if (dto.getPersona() != null && entity.getPersonas() != null) {

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/PersonaNaturalRequestDTO.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/PersonaNaturalRequestDTO.java
@@ -9,6 +9,8 @@ public class PersonaNaturalRequestDTO {
     private String documento;
     private String nombres;
     private String apellidos;
+    private Boolean cliente;
+    private String categoria;
 
     @Valid
     private PersonaRequestDTO persona;

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/PersonaNaturalResponseDTO.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/dto/PersonaNaturalResponseDTO.java
@@ -9,6 +9,8 @@ public class PersonaNaturalResponseDTO {
     private String documento;
     private String nombres;
     private String apellidos;
+    private Boolean cliente;
+    private String categoria;
     private LocalDateTime creado;
     private LocalDateTime actualizado;
     private PersonaResponseDTO persona;

--- a/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/PersonaNatural.java
+++ b/everywhere-backend/src/main/java/com/everywhere/backend/model/entity/PersonaNatural.java
@@ -23,6 +23,12 @@ public class PersonaNatural {
     @Column(name = "per_nat_apell_vac")
     private String apellidos;
 
+    @Column(name = "per_nat_cliente_bol")
+    private Boolean cliente;
+
+    @Column(name = "per_nat_catg_vac")
+    private String categoria;
+
     @Column(name = "per_nat_cre_tmp", updatable = false)
     private LocalDateTime creado;
 


### PR DESCRIPTION
This pull request adds support for the `cliente` and `categoria` fields to the `PersonaNatural` entity, its associated DTOs, and the mapper logic. These changes ensure that both fields are properly stored, transferred, and updated across the application.

**Entity and database updates:**

* Added `cliente` (Boolean) and `categoria` (String) fields to the `PersonaNatural` entity, including their corresponding column mappings.

**DTO enhancements:**

* Included `cliente` and `categoria` fields in both `PersonaNaturalRequestDTO` and `PersonaNaturalResponseDTO` to allow these values to be sent and received via API requests and responses.

**Mapper logic improvements:**

* Updated the `PersonaNaturalMapper` to map `cliente` and `categoria` values from the request DTO to the entity during updates.